### PR TITLE
Ruff linter and formatter as pre-commit hooks

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,0 @@
-[settings]
-known_third_party =IPython,download_path,matplotlib,numpy,pandas,statsmodels

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,56 +10,27 @@ repos:
       - id: check-docstring-first
       - id: check-json
 
-  - repo: https://github.com/psf/black
-    rev: 23.12.1
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.12.10
     hooks:
-      - id: black
-        args: ["--line-length=88"]
+      # Run the linter.
+      - id: ruff-check
+        args: [--fix]
+      # Run the formatter.
+      - id: ruff-format
 
-  - repo: https://github.com/keewis/blackdoc
-    rev: v0.3.9
-    hooks:
-      - id: blackdoc
-
-  - repo: https://github.com/PyCQA/flake8
-    rev: 7.0.0
-    hooks:
-      - id: flake8
-        args: ["--max-line-length=88"]
-
+  # NOTE: Not sure if covered by ruff
   - repo: https://github.com/asottile/seed-isort-config
     rev: v2.2.0
     hooks:
       - id: seed-isort-config
-
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
-        args: ["--profile=black"]
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v3.1.0
     hooks:
       - id: prettier
         additional_dependencies: [prettier@v2.7.1]
-
-  - repo: https://github.com/nbQA-dev/nbQA
-    rev: 1.7.1
-    hooks:
-      - id: nbqa-black
-        additional_dependencies: [black]
-      - id: nbqa-pyupgrade
-        additional_dependencies: [pyupgrade]
-        exclude: foundations/quickstart.ipynb
-      - id: nbqa-isort
-        additional_dependencies: [isort]
-
-  - repo: https://github.com/s-weigand/flake8-nb
-    rev: "v0.5.3"
-    hooks:
-      - id: flake8-nb
-        args: ["--max-line-length=88"]
 
   - repo: https://github.com/kynan/nbstripout
     rev: 0.7.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,50 @@
+[tool.ruff]
+exclude = [
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".ipynb_checkpoints",
+    ".mypy_cache",
+    ".pyenv",
+    ".pytest_cache",
+    ".pytype",
+    ".ruff_cache",
+    ".venv",
+    ".vscode",
+    "__pypackages__",
+    "_build",
+    "build",
+    "dist",
+    "site-packages",
+    "venv",
+]
+line-length = 88
+indent-width = 4
+target-version = "py313"
+# unsafe-fixes = true
+
+[tool.ruff.lint]
+select = ["ALL"]  # Subsets could also be used if that is too much
+ignore = [
+    "ANN401", # Any type in func args are not allowed
+    "D203",   # no blank lines between class def and docstring
+    "D213",   # multiline summary should start in first line
+    "PGH",    # pygrep hooks are ignored
+    "TD002",  # todo author assignment is ignored
+    "TD003",  # todo issue assignment is ignored
+    "T201",   # allow print statements
+    "COM812", # missing trailing comma is disabled
+]
+fixable = ["ALL"]
+unfixable = []
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "auto"
+docstring-code-format = false  # maybe true? Should replace blackdoc
+docstring-code-line-length = "dynamic"
+
+[tool.ruff.lint.isort]
+known-third-party = ["IPython","download_path","matplotlib","numpy","pandas","statsmodels"]


### PR DESCRIPTION
Drop-in replacement for `black` and `isort`, but faster. 
Pre-commit Hooks would execute faster as less hooks are being run.

> [!IMPORTANT]
> Almost **ALL** (+800) of `ruff's` rules are being checked for.
> If that is an over-kill it can be limited to a subset, but I think that helps promote and practice best-practices in python.
> Rules can easily be ignored with the `pyproject.toml` file